### PR TITLE
Draft: Zephyr support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,18 +5,18 @@
 {
 	"version": "0.2.0",
 	"configurations": [
-        {
-            "args": [
-                "--extensionDevelopmentPath=${workspaceFolder}"
-            ],
-            "name": "Launch Extension",
-            "outFiles": [
-                "${workspaceFolder}/dist/**/*.js"
-            ],
-            "request": "launch",
-            "debugWebviews": true,
-            "type": "extensionHost"
-        },
+		{
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}"
+			],
+			"name": "Launch Extension",
+			"outFiles": [
+				"${workspaceFolder}/dist/**/*.js"
+			],
+			"request": "launch",
+			"debugWebviews": true,
+			"type": "extensionHost"
+		},
 		{
 			"name": "Extension Tests",
 			"type": "extensionHost",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,7 @@
         "cppdbg",
         "cspy",
         "esbuild",
+        "FLAGGROUP",
         "OSTCB",
         "pqueue",
         "Prio",
@@ -22,6 +23,7 @@
         "rqueue",
         "RTOSEMBOS",
         "RTOSUCOS",
+        "RTOSZEPHYR",
         "wabase",
         "wtobjp"
     ],

--- a/src/rtos/rtos-zephyr.ts
+++ b/src/rtos/rtos-zephyr.ts
@@ -1,0 +1,611 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import * as vscode from "vscode";
+import { DebugProtocol } from "@vscode/debugprotocol";
+import * as RTOSCommon from "./rtos-common";
+import { time } from "console";
+
+// We will have two rows of headers for Zephyr and the table below describes
+// the columns headers for the two rows and the width of each column as a fraction
+// of the overall space.
+enum DisplayFields {
+  Address,
+  TaskName,
+  Status,
+  Priority,
+  StackPercent,
+}
+
+const RTOSZEPHYRItems: { [key: string]: RTOSCommon.DisplayColumnItem } = {};
+RTOSZEPHYRItems[DisplayFields[DisplayFields.Address]] = {
+  width: 2,
+  headerRow1: "Thread",
+  headerRow2: "Address",
+  colGapBefore: 1,
+};
+RTOSZEPHYRItems[DisplayFields[DisplayFields.TaskName]] = {
+  width: 4,
+  headerRow1: "Thread",
+  headerRow2: "Name",
+  colGapBefore: 1,
+};
+RTOSZEPHYRItems[DisplayFields[DisplayFields.Status]] = {
+  width: 4,
+  headerRow1: "Thread",
+  headerRow2: "Status",
+  colType: RTOSCommon.ColTypeEnum.colTypeCollapse,
+};
+RTOSZEPHYRItems[DisplayFields[DisplayFields.Priority]] = {
+  width: 1,
+  headerRow1: "Thread",
+  headerRow2: "Priority",
+  colType: RTOSCommon.ColTypeEnum.colTypeNumeric,
+  colGapAfter: 1,
+}; // 3 are enough but 4 aligns better with header text
+RTOSZEPHYRItems[DisplayFields[DisplayFields.StackPercent]] = {
+  width: 4,
+  headerRow1: "Stack Usage",
+  headerRow2: "% (Used B / Size B)",
+  colType: RTOSCommon.ColTypeEnum.colTypePercentage,
+};
+
+const DisplayFieldNames: string[] = Object.keys(RTOSZEPHYRItems);
+
+export class RTOSZEPHYR extends RTOSCommon.RTOSBase {
+  // We keep a bunch of variable references (essentially pointers) that we can use to query for values
+  // Since all of them are global variable, we only need to create them once per session. These are
+  // similar to Watch/Hover variables
+  private stackEntrySize: number = 1; // TODO check if stack_info.size is always in Bytes
+
+  private kernel: RTOSCommon.RTOSVarHelperMaybe;
+
+  private current: RTOSCommon.RTOSVarHelperMaybe;
+  private currentVal: number = Number.MAX_SAFE_INTEGER;
+
+  private threads: RTOSCommon.RTOSVarHelperMaybe;
+
+  private stale: boolean = true;
+  private foundThreads: RTOSCommon.RTOSThreadInfo[] = [];
+  private finalThreads: RTOSCommon.RTOSThreadInfo[] = [];
+  private timeInfo: string = "";
+
+  private stackPattern = 0x00; // TODO find out what the default stack pattern is
+
+  /* As of https://docs.zephyrproject.org/latest/hardware/porting/arch.html - At present, Zephyr does not support stacks that grow upward. */
+  private stackIncrements = -1; // negative numbers => stack expands from higher address to lower addresses
+
+  private helpHtml: string | undefined;
+
+  constructor(public session: vscode.DebugSession) {
+    super(session, "Zephyr");
+
+    if (session.configuration.rtosViewConfig) {
+      if (session.configuration.rtosViewConfig.stackPattern) {
+        this.stackPattern = parseInt(session.configuration.rtosViewConfig.stackPattern);
+      }
+
+      if (session.configuration.rtosViewConfig.stackGrowth) {
+        this.stackIncrements = parseInt(session.configuration.rtosViewConfig.stackGrowth);
+      }
+    }
+  }
+
+  public async tryDetect(useFrameId: number): Promise<RTOSCommon.RTOSBase> {
+    this.progStatus = "stopped";
+    try {
+      if (this.status === "none") {
+        // We only get references to all the interesting variables. Note that any one of the following can fail
+        // and the caller may try again until we know that it definitely passed or failed. Note that while we
+        // re-try everything, we do remember what already had succeeded and don't waste time trying again. That
+        // is how this.getVarIfEmpty() works
+        this.kernel = await this.getVarIfEmpty(this.kernel, useFrameId, "_kernel", false);
+        this.current = await this.getVarIfEmpty(this.current, useFrameId, "_kernel.cpus[0].current", false);
+        this.threads = await this.getVarIfEmpty(this.threads, useFrameId, "_kernel.threads", true);
+        this.status = "initialized";
+      }
+      return this;
+    } catch (e) {
+      if (e instanceof RTOSCommon.ShouldRetry) {
+        console.error(e.message);
+      } else {
+        this.status = "failed";
+        this.failedWhy = e;
+      }
+      return this;
+    }
+  }
+
+  protected createHmlHelp(th: RTOSCommon.RTOSThreadInfo, thInfo: RTOSCommon.RTOSStrToValueMap) {
+    if (this.helpHtml === undefined) {
+      this.helpHtml = "";
+      try {
+        let ret: string = "";
+        function strong(text: string) {
+          return `<strong>${text}</strong>`;
+        }
+
+        if (!("name" in thInfo)) {
+          ret +=
+            `Thread name missing: Enable macro ${strong("CONFIG_THREAD_NAME")} and ` +
+            `use ${strong("k_thread_name_set")} in FW<br><br>`;
+        }
+        if (!th.stackInfo.stackSize) {
+          ret += `Stack information missing: Enable macro ${strong("CONFIG_THREAD_STACK_INFO")}`;
+        }
+
+        if (ret) {
+          ret += "Note: Make sure you consider the performance/resources impact for any changes to your FW.<br>\n";
+          this.helpHtml =
+            '<button class="help-button">Hints to get more out of the Zephyr RTOS View</button>\n' +
+            `<div class="help"><p>\n${ret}\n</p></div>\n`;
+        }
+      } catch (e) {
+        console.log(e);
+      }
+    }
+  }
+
+  public refresh(frameId: number): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      if (this.progStatus !== "stopped") {
+        resolve();
+        return;
+      }
+
+      const timer = new RTOSCommon.HrTimer();
+      this.stale = true;
+      this.timeInfo = new Date().toISOString();
+
+      this.foundThreads = [];
+      this.kernel?.getVarChildrenObj(frameId).then(
+        async (kernel) => {
+          try {
+            if (this.threads) {
+              const threadListStart = await this.threads?.getValue(frameId);
+              if (threadListStart && 0 !== parseInt(threadListStart)) {
+                const tmpCurrentVal = await this.current?.getValue(frameId);
+                this.currentVal = tmpCurrentVal ? parseInt(tmpCurrentVal) : Number.MAX_SAFE_INTEGER;
+
+                await this.getThreadInfo(this.threads, frameId);
+                this.foundThreads.sort(
+                  (a, b) => parseInt(a.display["Address"].text) - parseInt(b.display["Address"].text)
+                );
+              }
+            } else {
+              //TODO Somehow state that user should enable CONFIG_THREAD_MONITOR
+            }
+
+            this.finalThreads = [...this.foundThreads];
+
+            this.stale = false;
+            this.timeInfo += " in " + timer.deltaMs() + " ms";
+            resolve();
+          } catch (e) {
+            resolve();
+            console.error("Zephyr.refresh() failed: ", e);
+          }
+        },
+        (reason) => {
+          resolve();
+          console.error("Zephyr.refresh() failed: ", reason);
+        }
+      );
+    });
+  }
+
+  private getThreadInfo(tcbListEntry: RTOSCommon.RTOSVarHelperMaybe, frameId: number): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      if (!tcbListEntry || !tcbListEntry.varReference) {
+        resolve();
+        return;
+      }
+
+      if (this.progStatus !== "stopped") {
+        reject(new Error("Busy"));
+        return;
+      }
+
+      tcbListEntry.getVarChildrenObj(frameId).then(
+        async (obj: RTOSCommon.RTOSStrToValueMap) => {
+          try {
+            let curTaskObj = obj;
+            let thAddress = parseInt(tcbListEntry?.value || "");
+
+            do {
+              let thName = "???";
+              if (curTaskObj["name"]) {
+                const tmpThName = (await this.getExprVal("(char *)" + curTaskObj["name"]?.exp, frameId)) || "";
+                const matchName = tmpThName.match(/"([^*]*)"$/);
+                thName = matchName ? matchName[1] : tmpThName;
+              }
+
+              const threadRunning = thAddress === this.currentVal;
+
+              const curTaskObjBase = await this.getVarChildrenObj(curTaskObj.base.ref, "curTaskObjBase");
+
+              const thStateObject = await this.analyzeTaskState(curTaskObjBase);
+              const thState = thStateObject.describe();
+
+              const stackInfo = await this.getStackInfo(curTaskObj, this.stackPattern);
+
+              const display: { [key: string]: RTOSCommon.DisplayRowItem } = {};
+              const mySetter = (x: DisplayFields, text: string, value?: any) => {
+                display[DisplayFieldNames[x]] = { text, value };
+              };
+
+              mySetter(DisplayFields.Address, RTOSCommon.hexFormat(thAddress));
+              mySetter(DisplayFields.TaskName, thName);
+              mySetter(DisplayFields.Status, threadRunning ? "RUNNING" : thState, thStateObject.fullData());
+              mySetter(DisplayFields.Priority, curTaskObjBase ? parseInt(curTaskObjBase.prio.val).toString() : "???");
+
+              if (stackInfo.stackUsed !== undefined && stackInfo.stackSize !== undefined) {
+                const stackPercentVal = Math.round((stackInfo.stackUsed / stackInfo.stackSize) * 100);
+                const stackPercentText = `${stackPercentVal} % (${stackInfo.stackUsed} / ${stackInfo.stackSize})`;
+                mySetter(DisplayFields.StackPercent, stackPercentText, stackPercentVal);
+              } else {
+                mySetter(DisplayFields.StackPercent, "?? %");
+              }
+
+              const thread: RTOSCommon.RTOSThreadInfo = {
+                display: display,
+                stackInfo: stackInfo,
+                running: threadRunning,
+              };
+              this.foundThreads.push(thread);
+              this.createHmlHelp(thread, curTaskObj);
+
+              thAddress = parseInt(curTaskObj.next_thread?.val);
+              if (0 !== thAddress) {
+                const nextThreadObj = await this.getVarChildrenObj(curTaskObj.next_thread?.ref, "next_thread");
+                curTaskObj = nextThreadObj || {};
+              }
+            } while (0 !== thAddress);
+
+            resolve();
+          } catch (e) {
+            console.log("RTOSZEPHYR.getThreadInfo() error", e);
+          }
+        },
+        (e) => {
+          reject(e);
+        }
+      );
+    });
+  }
+
+  protected async getEventInfo(
+    address: number,
+    eventObject: RTOSCommon.RTOSStrToValueMap,
+    timeoutVal: number | null
+  ): Promise<EventInfo> {
+    // TODO Try to get actual event task is pending on
+    const eventType = OsEventType.Generic; // TODO Get event type from actual event => via eventObject["waitq"]?.val somehow?
+    const eventInfo: EventInfo = { address, eventType: eventType };
+
+    if (timeoutVal) {
+      eventInfo.timeout = timeoutVal;
+    }
+
+    // TODO Try to readout things like event object name here and add it if valid
+
+    return eventInfo;
+  }
+
+  protected async getTaskTimeout(curTaskObjBase: RTOSCommon.RTOSStrToValueMap | null): Promise<number | null> {
+    let timeoutValue = null;
+    if (curTaskObjBase !== null && curTaskObjBase["timeout"]?.ref) {
+      const timeout = await this.getVarChildrenObj(curTaskObjBase.timeout?.ref, "timeout");
+      if (timeout) {
+        timeoutValue = parseInt(timeout.dticks.val);
+      }
+    }
+    return timeoutValue;
+  }
+
+  protected async analyzeTaskState(curTaskObjBase: RTOSCommon.RTOSStrToValueMap | null): Promise<TaskState> {
+    if (curTaskObjBase === null) {
+      return new TaskStateInvalid();
+    } else {
+      const state = parseInt(curTaskObjBase.thread_state.val);
+      const timeoutValue = await this.getTaskTimeout(curTaskObjBase);
+      switch (state) {
+        case OsTaskState.DUMMY:
+          return new TaskDummy();
+        case OsTaskState.PENDING:
+          const resultState = new TaskPending();
+          resultState.addEventType(OsEventType.Generic);
+          if (curTaskObjBase.pended_on?.val) {
+            const eventWaitQAddress = parseInt(curTaskObjBase.pended_on?.val);
+            if (eventWaitQAddress !== 0) {
+              const event = await this.getVarChildrenObj(curTaskObjBase.pended_on?.ref, "pended_on");
+              if (event) {
+                const eventInfo = await this.getEventInfo(eventWaitQAddress, event, timeoutValue);
+                resultState.addEvent(eventInfo);
+              }
+            }
+          } else {
+            if (timeoutValue) {
+              const eventInfo: EventInfo = { address: 0x00, eventType: OsEventType.Generic, timeout: timeoutValue };
+            }
+          }
+          return resultState;
+        case OsTaskState.PRESTART:
+          return new TaskPrestart();
+        case OsTaskState.DEAD:
+          return new TaskStateInvalid();
+        case OsTaskState.SUSPENDED:
+          return new TaskSuspended(timeoutValue);
+        case OsTaskState.ABORTING:
+          return new TaskAborting();
+        case OsTaskState.READY:
+          return new TaskReady();
+        default: {
+          return new TaskStateInvalid();
+        }
+      }
+    }
+  }
+
+  protected async getStackInfo(thInfo: RTOSCommon.RTOSStrToValueMap | null, stackPattern: number) {
+    const stackInfo: RTOSCommon.RTOSStackInfo = {
+      stackStart: 0,
+      stackTop: 0,
+    };
+
+    if (thInfo === null) {
+      return stackInfo;
+    }
+
+    if (thInfo.callee_saved === null) {
+      return stackInfo;
+    }
+    const callee_saved = await this.getVarChildrenObj(thInfo.callee_saved.ref, "callee_saved");
+    if (callee_saved === null) {
+      return stackInfo;
+    }
+
+    const TopOfStack = callee_saved.psp.val; // FIXME This is not right for all arches => include\zephyr\arch\....\thread.h
+    stackInfo.stackTop = parseInt(TopOfStack);
+
+    /* only available with CONFIG_THREAD_STACK_INFO (optional) */
+    if (thInfo.stack_info !== null) {
+      const stack_info = await this.getVarChildrenObj(thInfo.stack_info.ref, "stack_info");
+      if (stack_info !== null) {
+        const StackSize = stack_info["size"]?.val;
+        const StackStart = stack_info["start"]?.val;
+        const StackDelta = stack_info["delta"]?.val;
+
+        if (StackSize && StackStart && StackDelta) {
+          if (this.stackIncrements < 0) {
+            stackInfo.stackStart =
+              parseInt(StackStart) +
+              parseInt(StackSize) * this.stackEntrySize -
+              parseInt(StackDelta) * this.stackEntrySize;
+            stackInfo.stackEnd = parseInt(StackStart);
+          } else {
+            stackInfo.stackStart = parseInt(StackStart) + parseInt(StackDelta) * this.stackEntrySize;
+            stackInfo.stackEnd = parseInt(StackStart) + parseInt(StackSize) * this.stackEntrySize;
+          }
+
+          stackInfo.stackSize = parseInt(StackSize) * this.stackEntrySize;
+
+          if (this.stackIncrements < 0) {
+            const stackDelta = stackInfo.stackStart - stackInfo.stackTop;
+            stackInfo.stackFree = stackInfo.stackSize - stackDelta;
+            stackInfo.stackUsed = stackDelta;
+          } else {
+            const stackDelta = stackInfo.stackTop - stackInfo.stackStart;
+            stackInfo.stackFree = stackDelta;
+            stackInfo.stackUsed = stackInfo.stackSize - stackDelta;
+          }
+        }
+      }
+    } else {
+      /* As stackStart is mandatory, we need to set it to some reasonable value */
+      stackInfo.stackStart = stackInfo.stackTop;
+    }
+
+    return stackInfo;
+  }
+
+  public lastValidHtmlContent: RTOSCommon.HtmlInfo = { html: "", css: "" };
+  public getHTML(): RTOSCommon.HtmlInfo {
+    const htmlContent: RTOSCommon.HtmlInfo = {
+      html: "",
+      css: "",
+    };
+    // WARNING: This stuff is super fragile. Once we know how this works, then we should refactor this
+    let msg = "";
+    if (this.status === "none") {
+      htmlContent.html = "<p>RTOS not yet fully initialized. Will occur next time program pauses</p>\n";
+      return htmlContent;
+    } else if (this.stale) {
+      const lastHtmlInfo = this.lastValidHtmlContent;
+      msg = " Following info from last query may be stale.";
+      htmlContent.html = `<p>Unable to collect full RTOS information.${msg}</p>\n` + lastHtmlInfo.html;
+      htmlContent.css = lastHtmlInfo.css;
+      return htmlContent;
+    } else if (this.finalThreads.length === 0) {
+      htmlContent.html = `<p>No ${this.name} threads detected, perhaps RTOS not yet initialized or tasks yet to be created!</p>\n`;
+      return htmlContent;
+    }
+
+    const ret = this.getHTMLCommon(DisplayFieldNames, RTOSZEPHYRItems, this.finalThreads, this.timeInfo);
+    htmlContent.html = msg + ret.html + (this.helpHtml || "");
+    htmlContent.css = ret.css;
+
+    this.lastValidHtmlContent = htmlContent;
+    // console.log(this.lastValidHtmlContent.html);
+    return this.lastValidHtmlContent;
+  }
+}
+
+enum OsTaskState {
+  DUMMY = 0x00 /* _THREAD_DUMMY / Not a real thread */,
+  PENDING = 0x01 /* _THREAD_PENDING / Waiting */,
+  PRESTART = 0x02 /* _THREAD_PRESTART / New */,
+  DEAD = 0x04 /* _THREAD_DEAD / Terminated */,
+  SUSPENDED = 0x10 /* _THREAD_SUSPENDED / Suspended (thread is not active until k_wakeup() is called on thread) */,
+  ABORTING = 0x20 /* _THREAD_ABORTING / abort in progress */,
+  READY = 0x80 /* _THREAD_QUEUED / Ready */,
+}
+
+enum OsEventType {
+  Generic = 1,
+}
+
+abstract class TaskState {
+  public abstract describe(): string;
+  public abstract fullData(): any;
+}
+
+class TaskReady extends TaskState {
+  public describe(): string {
+    return "READY";
+  }
+
+  public fullData(): any {
+    return null;
+  }
+}
+
+class TaskSuspended extends TaskState {
+  private timeout?: number | null;
+
+  constructor(timeout: number | null) {
+    super();
+    this.timeout = timeout;
+  }
+
+  public describe(): string {
+    let suspendDescription = "SUSPENDED";
+    if (this.timeout && this.timeout !== 0) {
+      suspendDescription += ` for: ${this.timeout.toString()} ms`;
+    }
+    return suspendDescription;
+  }
+
+  public fullData(): any {
+    return null;
+  }
+}
+
+class TaskAborting extends TaskState {
+  public describe(): string {
+    return "ABORTING";
+  }
+
+  public fullData(): any {
+    return null;
+  }
+}
+
+class TaskPrestart extends TaskState {
+  public describe(): string {
+    return "PRESTART";
+  }
+
+  public fullData(): any {
+    return null;
+  }
+}
+
+class TaskDummy extends TaskState {
+  public describe(): string {
+    return "DUMMY";
+  }
+
+  public fullData(): any {
+    return null;
+  }
+}
+
+class TaskStateInvalid extends TaskState {
+  public describe(): string {
+    return "???";
+  }
+
+  public fullData(): any {
+    return null;
+  }
+}
+
+class TaskPending extends TaskState {
+  private pendingInfo: Map<OsEventType, EventInfo[]>;
+
+  constructor() {
+    super();
+    this.pendingInfo = new Map();
+  }
+
+  public addEvent(event: EventInfo) {
+    this.addEventType(event.eventType);
+    this.pendingInfo.get(event.eventType)?.push(event);
+  }
+
+  public addEventType(eventType: OsEventType) {
+    if (!this.pendingInfo.has(eventType)) {
+      this.pendingInfo.set(eventType, []);
+    }
+  }
+
+  public describe(): string {
+    // Converting to an array here is inefficient, but JS has no builtin iterator map/reduce feature
+    const eventCount = [...this.pendingInfo.values()].reduce((acc, events) => acc + events.length, 0);
+
+    if (eventCount <= 1) {
+      let event: EventInfo | undefined;
+      for (const events of this.pendingInfo.values()) {
+        if (events.length > 0) {
+          event = events[0];
+        }
+      }
+
+      if (event) {
+        const eventTypeStr = OsEventType[event.eventType] ? OsEventType[event.eventType] : "Unknown";
+        return `PEND ${eventTypeStr}: ${describeEvent(event)}`;
+      } else {
+        // This should not happen, but we still keep it as a fallback
+        return "PEND Unknown";
+      }
+    } else {
+      return "PEND MULTI";
+    }
+  }
+
+  public fullData() {
+    // Build an object containing mapping event types to event descriptions
+    const result: any = {};
+    const eventTypes = [...this.pendingInfo.keys()];
+    eventTypes.sort();
+    for (const eventType of eventTypes) {
+      result[OsEventType[eventType]] = [];
+      for (const event of this.pendingInfo.get(eventType) || []) {
+        result[OsEventType[eventType]].push(describeEvent(event));
+      }
+    }
+
+    return result;
+  }
+}
+
+interface EventInfo {
+  name?: string;
+  timeout?: number;
+  address: number;
+  eventType: OsEventType;
+}
+
+function describeEvent(event: EventInfo): string {
+  let eventDescription: string = "";
+  if (event.name && event.name !== "?") {
+    eventDescription = event.name;
+  } else {
+    eventDescription = `0x${event.address.toString(16)}`;
+  }
+
+  if (event.timeout && event.timeout !== 0) {
+    eventDescription += `, timeout: ${event.timeout.toString()}`;
+  }
+
+  return eventDescription;
+}

--- a/src/rtos/rtos-zephyr.ts
+++ b/src/rtos/rtos-zephyr.ts
@@ -68,8 +68,6 @@ export class RTOSZEPHYR extends RTOSCommon.RTOSBase {
   private finalThreads: RTOSCommon.RTOSThreadInfo[] = [];
   private timeInfo: string = "";
 
-  private stackPattern = 0x00; // TODO find out what the default stack pattern is
-
   /* As of https://docs.zephyrproject.org/latest/hardware/porting/arch.html - At present, Zephyr does not support stacks that grow upward. */
   private stackIncrements = -1; // negative numbers => stack expands from higher address to lower addresses
 
@@ -79,10 +77,6 @@ export class RTOSZEPHYR extends RTOSCommon.RTOSBase {
     super(session, "Zephyr");
 
     if (session.configuration.rtosViewConfig) {
-      if (session.configuration.rtosViewConfig.stackPattern) {
-        this.stackPattern = parseInt(session.configuration.rtosViewConfig.stackPattern);
-      }
-
       if (session.configuration.rtosViewConfig.stackGrowth) {
         this.stackIncrements = parseInt(session.configuration.rtosViewConfig.stackGrowth);
       }
@@ -225,7 +219,7 @@ export class RTOSZEPHYR extends RTOSCommon.RTOSBase {
               const thStateObject = await this.analyzeTaskState(curTaskObjBase);
               const thState = thStateObject.describe();
 
-              const stackInfo = await this.getStackInfo(curTaskObj, this.stackPattern);
+              const stackInfo = await this.getStackInfo(curTaskObj);
 
               const display: { [key: string]: RTOSCommon.DisplayRowItem } = {};
               const mySetter = (x: DisplayFields, text: string, value?: any) => {
@@ -346,7 +340,7 @@ export class RTOSZEPHYR extends RTOSCommon.RTOSBase {
     }
   }
 
-  protected async getStackInfo(thInfo: RTOSCommon.RTOSStrToValueMap | null, stackPattern: number) {
+  protected async getStackInfo(thInfo: RTOSCommon.RTOSStrToValueMap | null) {
     const stackInfo: RTOSCommon.RTOSStackInfo = {
       stackStart: 0,
       stackTop: 0,

--- a/src/rtos/rtos-zephyr.ts
+++ b/src/rtos/rtos-zephyr.ts
@@ -325,6 +325,7 @@ export class RTOSZEPHYR extends RTOSCommon.RTOSBase {
           } else {
             if (timeoutValue) {
               const eventInfo: EventInfo = { address: 0x00, eventType: OsEventType.Generic, timeout: timeoutValue };
+              resultState.addEvent(eventInfo);
             }
           }
           return resultState;

--- a/src/rtos/rtos.ts
+++ b/src/rtos/rtos.ts
@@ -1,480 +1,496 @@
-import { DebugProtocol } from '@vscode/debugprotocol';
-import * as vscode from 'vscode';
-import * as os from 'os';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as RTOSCommon from './rtos-common';
-import { RTOSFreeRTOS } from './rtos-freertos';
-import { RTOSUCOS2 } from './rtos-ucosii';
-import { RTOSEmbOS } from './rtos-embos';
-import { RTOSChibiOS } from './rtos-chibios';
+import { DebugProtocol } from "@vscode/debugprotocol";
+import * as vscode from "vscode";
+import * as os from "os";
+import * as fs from "fs";
+import * as path from "path";
+import * as RTOSCommon from "./rtos-common";
+import { RTOSFreeRTOS } from "./rtos-freertos";
+import { RTOSUCOS2 } from "./rtos-ucosii";
+import { RTOSEmbOS } from "./rtos-embos";
+import { RTOSChibiOS } from "./rtos-chibios";
+import { RTOSZEPHYR } from "./rtos-zephyr";
 
 import {
-    IDebugTracker,
-    IDebuggerTrackerSubscribeArg,
-    IDebuggerTrackerEvent,
-    IDebuggerSubscription,
-    OtherDebugEvents,
-    DebugSessionStatus,
-    DebugTracker
-} from 'debug-tracker-vscode';
+  IDebugTracker,
+  IDebuggerTrackerSubscribeArg,
+  IDebuggerTrackerEvent,
+  IDebuggerSubscription,
+  OtherDebugEvents,
+  DebugSessionStatus,
+  DebugTracker,
+} from "debug-tracker-vscode";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const TrackedDebuggers = [
-    'cortex-debug',
-    'cppdbg',       // Microsoft debugger
-    'cspy'          // IAR debugger
+  "cortex-debug",
+  "cppdbg", // Microsoft debugger
+  "cspy", // IAR debugger
 ];
 
 let trackerApi: IDebugTracker;
 let trackerApiClientInfo: IDebuggerSubscription;
 
 const RTOS_TYPES = {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    'FreeRTOS': RTOSFreeRTOS,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    'uC/OS-II': RTOSUCOS2,
-    'embOS': RTOSEmbOS,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    'ChibiOS': RTOSChibiOS
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  FreeRTOS: RTOSFreeRTOS,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  "uC/OS-II": RTOSUCOS2,
+  embOS: RTOSEmbOS,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  ChibiOS: RTOSChibiOS,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  Zephyr: RTOSZEPHYR,
 };
 
-const defaultHtmlInfo: RTOSCommon.HtmlInfo = { html: '', css: '' };
+const defaultHtmlInfo: RTOSCommon.HtmlInfo = { html: "", css: "" };
 
 export class RTOSSession {
-    public lastFrameId: number | undefined;
-    public htmlContent: RTOSCommon.HtmlInfo = defaultHtmlInfo;
-    public rtos: RTOSCommon.RTOSBase | undefined; // The final RTOS
-    private allRTOSes: RTOSCommon.RTOSBase[] = [];
-    public triedAndFailed = false;
+  public lastFrameId: number | undefined;
+  public htmlContent: RTOSCommon.HtmlInfo = defaultHtmlInfo;
+  public rtos: RTOSCommon.RTOSBase | undefined; // The final RTOS
+  private allRTOSes: RTOSCommon.RTOSBase[] = [];
+  public triedAndFailed = false;
 
-    constructor(public session: vscode.DebugSession) {
-        this.lastFrameId = undefined;
-        for (const rtosType of Object.values(RTOS_TYPES)) {
-            this.allRTOSes.push(new rtosType(session));
-        }
+  constructor(public session: vscode.DebugSession) {
+    this.lastFrameId = undefined;
+    for (const rtosType of Object.values(RTOS_TYPES)) {
+      this.allRTOSes.push(new rtosType(session));
     }
+  }
 
-    // This is the work horse. Do not call it if the panel is in disabled state.
-    public async onStopped(frameId: number): Promise<void> {
-        return new Promise<void>(async (resolve, reject) => {
-            this.lastFrameId = frameId;
-            const doRefresh = () => {
-                if (this.rtos) {
-                    this.htmlContent.html = '<p>RTOS Views: Failed to get RTOS information. Please report an issue if RTOS is actually running</p>\n';
-                    this.htmlContent.css = '';
-                    this.rtos.onStopped(frameId).then(() => {
-                        this.htmlContent = this.rtos?.getHTML() || defaultHtmlInfo;
-                        resolve();
-                    });
-                } else {
-                    this.triedAndFailed = true;
-                    this.htmlContent.html = '';
-                    this.htmlContent.css = '';
-                    resolve();
-                }
-            };
+  // This is the work horse. Do not call it if the panel is in disabled state.
+  public async onStopped(frameId: number): Promise<void> {
+    return new Promise<void>(async (resolve, reject) => {
+      this.lastFrameId = frameId;
+      const doRefresh = () => {
+        if (this.rtos) {
+          this.htmlContent.html =
+            "<p>RTOS Views: Failed to get RTOS information. Please report an issue if RTOS is actually running</p>\n";
+          this.htmlContent.css = "";
+          this.rtos.onStopped(frameId).then(() => {
+            this.htmlContent = this.rtos?.getHTML() || defaultHtmlInfo;
+            resolve();
+          });
+        } else {
+          this.triedAndFailed = true;
+          this.htmlContent.html = "";
+          this.htmlContent.css = "";
+          resolve();
+        }
+      };
 
-            if (this.rtos === undefined && this.allRTOSes.length > 0) {
-                // Let them all work in parallel. Since this will generate a ton of gdb traffic and traffic from other sources
-                // like variable, watch windows, things can fail. But our own backend queues things up so failures are unlikely
-                // With some other backend (if for instance we support cppdbg), not sure what happens. Worst case, try one OS
-                // at a time.
-                const promises = [];
-                for (const rtos of this.allRTOSes) {
-                    promises.push(rtos.tryDetect(frameId));
-                }
+      if (this.rtos === undefined && this.allRTOSes.length > 0) {
+        // Let them all work in parallel. Since this will generate a ton of gdb traffic and traffic from other sources
+        // like variable, watch windows, things can fail. But our own backend queues things up so failures are unlikely
+        // With some other backend (if for instance we support cppdbg), not sure what happens. Worst case, try one OS
+        // at a time.
+        const promises = [];
+        for (const rtos of this.allRTOSes) {
+          promises.push(rtos.tryDetect(frameId));
+        }
 
-                Promise.all(promises).then((results) => {
-                    for (const rtos of results) {
-                        if (rtos.status === 'failed') {
-                            const ix = this.allRTOSes.findIndex((v) => v === rtos);
-                            this.allRTOSes.splice(ix, 1);
-                            if (this.allRTOSes.length === 0) {
-                                doRefresh();
-                                break;
-                            }
-                        } else if (rtos.status === 'initialized') {
-                            this.allRTOSes = [];
-                            this.rtos = rtos;
-                            doRefresh();
-                            break;
-                        }
-                    }
-                    if (this.allRTOSes.length > 0) {
-                        // Some RTOSes have not finished detection
-                        this.htmlContent.html = '<p>RTOS Views: RTOS detection in progress...</p>\n';
-                        this.htmlContent.css = '';
-                        resolve();
-                    }
-                });
-            } else {
+        Promise.all(promises).then((results) => {
+          for (const rtos of results) {
+            if (rtos.status === "failed") {
+              const ix = this.allRTOSes.findIndex((v) => v === rtos);
+              this.allRTOSes.splice(ix, 1);
+              if (this.allRTOSes.length === 0) {
                 doRefresh();
+                break;
+              }
+            } else if (rtos.status === "initialized") {
+              this.allRTOSes = [];
+              this.rtos = rtos;
+              doRefresh();
+              break;
             }
+          }
+          if (this.allRTOSes.length > 0) {
+            // Some RTOSes have not finished detection
+            this.htmlContent.html = "<p>RTOS Views: RTOS detection in progress...</p>\n";
+            this.htmlContent.css = "";
+            resolve();
+          }
         });
-    }
+      } else {
+        doRefresh();
+      }
+    });
+  }
 
-    public onContinued(): void {
-        this.lastFrameId = undefined;
-        if (this.rtos) {
-            this.rtos.onContinued();
-        }
+  public onContinued(): void {
+    this.lastFrameId = undefined;
+    if (this.rtos) {
+      this.rtos.onContinued();
     }
+  }
 
-    public onExited(): void {
-        if (this.rtos) {
-            this.rtos.onExited();
-        }
-        this.lastFrameId = undefined;
-        this.rtos = undefined;
+  public onExited(): void {
+    if (this.rtos) {
+      this.rtos.onExited();
     }
+    this.lastFrameId = undefined;
+    this.rtos = undefined;
+  }
 
-    public refresh(): Promise<void> {
-        if (this.lastFrameId !== undefined) {
-            return this.onStopped(this.lastFrameId);
-        }
-        return new Promise<void>((r) => r());
+  public refresh(): Promise<void> {
+    if (this.lastFrameId !== undefined) {
+      return this.onStopped(this.lastFrameId);
     }
+    return new Promise<void>((r) => r());
+  }
 }
 
 interface DebugEventHandler {
-    onStarted(session: vscode.DebugSession): void;
-    onTerminated(session: vscode.DebugSession): void;
-    onStopped(session: vscode.DebugSession, frameId: number | undefined): void;
-    onContinued(session: vscode.DebugSession): void;
+  onStarted(session: vscode.DebugSession): void;
+  onTerminated(session: vscode.DebugSession): void;
+  onStopped(session: vscode.DebugSession, frameId: number | undefined): void;
+  onContinued(session: vscode.DebugSession): void;
 }
 
 class MyDebugTracker {
-    constructor(public context: vscode.ExtensionContext, protected handler: DebugEventHandler) {
-        context.subscriptions.push(
-            // vscode.workspace.onDidChangeConfiguration(this.settingsChanged.bind(this))
-        );
-        // this.updateTrackedDebuggersFromSettings();
-        this.subscribeToTracker();
-    }
+  constructor(public context: vscode.ExtensionContext, protected handler: DebugEventHandler) {
+    context.subscriptions
+      .push
+      // vscode.workspace.onDidChangeConfiguration(this.settingsChanged.bind(this))
+      ();
+    // this.updateTrackedDebuggersFromSettings();
+    this.subscribeToTracker();
+  }
 
-    public isActive() {
-        return !!trackerApiClientInfo;
-    }
+  public isActive() {
+    return !!trackerApiClientInfo;
+  }
 
-    private subscribeToTracker(): Promise<boolean> {
-        return new Promise<boolean>(async (resolve) => {
-            DebugTracker.getTrackerExtension('rtos-views').then((ret) => {
-                if (ret instanceof Error) {
-                    vscode.window.showErrorMessage(ret.message);
-                    resolve(false);
-                } else {
-                    trackerApi = ret;
-                    const arg: IDebuggerTrackerSubscribeArg = {
-                        version: 1,
-                        body: {
-                            debuggers: TrackedDebuggers,
-                            handler: this.debugTrackerEventHandler.bind(this),
-                            wantCurrentStatus: true,
-                            notifyAllEvents: false,
-                            // Make sure you set debugLevel to zero for production
-                            debugLevel: 0
-                        }
-                    };
-                    const result = trackerApi.subscribe(arg);
-                    if (typeof result === 'string') {
-                        vscode.window.showErrorMessage(`Subscription failed with extension 'debug-tracker-vscode' : ${result}`);
-                        resolve(false);
-                    } else {
-                        trackerApiClientInfo = result;
-                        resolve(true);
-                    }
-                }
-            });
-        });
-    }
+  private subscribeToTracker(): Promise<boolean> {
+    return new Promise<boolean>(async (resolve) => {
+      DebugTracker.getTrackerExtension("rtos-views").then((ret) => {
+        if (ret instanceof Error) {
+          vscode.window.showErrorMessage(ret.message);
+          resolve(false);
+        } else {
+          trackerApi = ret;
+          const arg: IDebuggerTrackerSubscribeArg = {
+            version: 1,
+            body: {
+              debuggers: TrackedDebuggers,
+              handler: this.debugTrackerEventHandler.bind(this),
+              wantCurrentStatus: true,
+              notifyAllEvents: false,
+              // Make sure you set debugLevel to zero for production
+              debugLevel: 0,
+            },
+          };
+          const result = trackerApi.subscribe(arg);
+          if (typeof result === "string") {
+            vscode.window.showErrorMessage(`Subscription failed with extension 'debug-tracker-vscode' : ${result}`);
+            resolve(false);
+          } else {
+            trackerApiClientInfo = result;
+            resolve(true);
+          }
+        }
+      });
+    });
+  }
 
-    static allSessions: { [sessionId: string]: vscode.DebugSession } = {};
-    async debugTrackerEventHandler(event: IDebuggerTrackerEvent) {
-        let session = MyDebugTracker.allSessions[event.sessionId];
-        const isNewSession = !session && event.session;
-        if (event.session) {
-            session = event.session;
-            MyDebugTracker.allSessions[event.sessionId] = session;
-        }
-        if (!session) {
-            // THis should not happen
-            console.error('rtos-views: Could not find session ' + event.sessionId);
-            return;
-        }
-        if (isNewSession) {
-            this.handler.onStarted(session);
-        }
-        switch (event.event) {
-            case OtherDebugEvents.FirstStackTrace: {
-                const frameId = event.stackTrace && event.stackTrace.body.stackFrames && event.stackTrace.body.stackFrames[0].id || undefined;
-                this.handler.onStopped(session, frameId);
-                break;
-            }
-            case DebugSessionStatus.Running: {
-                this.handler.onContinued(session);
-                break;
-            }
-            case OtherDebugEvents.Capabilities: {
-                // Maybe we do something here
-                break;
-            }
-            case DebugSessionStatus.Terminated: {
-                delete MyDebugTracker.allSessions[event.sessionId];
-                this.handler.onTerminated(session);
-                break;
-            }
-        }
+  static allSessions: { [sessionId: string]: vscode.DebugSession } = {};
+  async debugTrackerEventHandler(event: IDebuggerTrackerEvent) {
+    let session = MyDebugTracker.allSessions[event.sessionId];
+    const isNewSession = !session && event.session;
+    if (event.session) {
+      session = event.session;
+      MyDebugTracker.allSessions[event.sessionId] = session;
     }
+    if (!session) {
+      // THis should not happen
+      console.error("rtos-views: Could not find session " + event.sessionId);
+      return;
+    }
+    if (isNewSession) {
+      this.handler.onStarted(session);
+    }
+    switch (event.event) {
+      case OtherDebugEvents.FirstStackTrace: {
+        const frameId =
+          (event.stackTrace && event.stackTrace.body.stackFrames && event.stackTrace.body.stackFrames[0].id) ||
+          undefined;
+        this.handler.onStopped(session, frameId);
+        break;
+      }
+      case DebugSessionStatus.Running: {
+        this.handler.onContinued(session);
+        break;
+      }
+      case OtherDebugEvents.Capabilities: {
+        // Maybe we do something here
+        break;
+      }
+      case DebugSessionStatus.Terminated: {
+        delete MyDebugTracker.allSessions[event.sessionId];
+        this.handler.onTerminated(session);
+        break;
+      }
+    }
+  }
 }
 
 export class RTOSTracker implements DebugEventHandler {
-    private sessionMap: Map<string, RTOSSession> = new Map<string, RTOSSession>();
-    private provider: RTOSViewProvider;
-    private theTracker: MyDebugTracker;
-    public enabled: boolean;
-    public visible: boolean;
+  private sessionMap: Map<string, RTOSSession> = new Map<string, RTOSSession>();
+  private provider: RTOSViewProvider;
+  private theTracker: MyDebugTracker;
+  public enabled: boolean;
+  public visible: boolean;
 
-    constructor(private context: vscode.ExtensionContext) {
-        this.provider = new RTOSViewProvider(context.extensionUri, this);
-        this.theTracker = new MyDebugTracker(context, this);
-        const config = vscode.workspace.getConfiguration('mcu-debug.rtos-views', null);
+  constructor(private context: vscode.ExtensionContext) {
+    this.provider = new RTOSViewProvider(context.extensionUri, this);
+    this.theTracker = new MyDebugTracker(context, this);
+    const config = vscode.workspace.getConfiguration("mcu-debug.rtos-views", null);
 
-        this.enabled = config.get('showRTOS', true);
-        this.visible = this.enabled;
-        vscode.commands.executeCommand('setContext', 'mcu-debug.rtos-views:showRTOS', this.enabled);
-        context.subscriptions.push(
-            vscode.window.registerWebviewViewProvider(RTOSViewProvider.viewType, this.provider),
-            vscode.workspace.onDidChangeConfiguration(this.settingsChanged.bind(this)),
-            vscode.commands.registerCommand('mcu-debug.rtos-views.toggleRTOSPanel', this.toggleRTOSPanel.bind(this)),
-            vscode.commands.registerCommand('mcu-debug.rtos-views.refresh', this.update.bind(this))
-        );
+    this.enabled = config.get("showRTOS", true);
+    this.visible = this.enabled;
+    vscode.commands.executeCommand("setContext", "mcu-debug.rtos-views:showRTOS", this.enabled);
+    context.subscriptions.push(
+      vscode.window.registerWebviewViewProvider(RTOSViewProvider.viewType, this.provider),
+      vscode.workspace.onDidChangeConfiguration(this.settingsChanged.bind(this)),
+      vscode.commands.registerCommand("mcu-debug.rtos-views.toggleRTOSPanel", this.toggleRTOSPanel.bind(this)),
+      vscode.commands.registerCommand("mcu-debug.rtos-views.refresh", this.update.bind(this))
+    );
+  }
+
+  private settingsChanged(e: vscode.ConfigurationChangeEvent) {
+    if (e.affectsConfiguration("mcu-debug.rtos-views.showRTOS")) {
+      const config = vscode.workspace.getConfiguration("mcu-debug.rtos-views", null);
+      this.enabled = config.get("showRTOS", true);
+      vscode.commands.executeCommand("setContext", "mcu-debug.rtos-views:showRTOS", this.enabled);
+      this.update();
     }
+  }
 
-    private settingsChanged(e: vscode.ConfigurationChangeEvent) {
-        if (e.affectsConfiguration('mcu-debug.rtos-views.showRTOS')) {
-            const config = vscode.workspace.getConfiguration('mcu-debug.rtos-views', null);
-            this.enabled = config.get('showRTOS', true);
-            vscode.commands.executeCommand('setContext', 'mcu-debug.rtos-views:showRTOS', this.enabled);
-            this.update();
-        }
-    }
-
-    public onStopped(session: vscode.DebugSession, frameId: number) {
-        for (const rtosSession of this.sessionMap.values()) {
-            if (rtosSession.session.id === session.id) {
-                rtosSession.lastFrameId = frameId;
-                if (this.enabled && this.visible) {
-                    rtosSession.onStopped(frameId).then(() => {
-                        this.provider.updateHtml();
-                    });
-                }
-                break;
-            }
-        }
-    }
-
-    public onContinued(session: vscode.DebugSession) {
-        for (const rtosSession of this.sessionMap.values()) {
-            if (rtosSession.session.id === session.id) {
-                rtosSession.onContinued();
-            }
-        }
-    }
-
-    public onStarted(session: vscode.DebugSession) {
-        this.sessionMap.set(session.id, new RTOSSession(session));
-    }
-
-    public onTerminated(session: vscode.DebugSession) {
-        const s = this.sessionMap.get(session.id);
-        if (s) {
-            s.onExited();
-            this.sessionMap.delete(session.id);
-        }
-    }
-
-    // Only updates the RTOS state. Only debug sessions that are currently stopped will be updated
-    public async updateRTOSInfo(): Promise<any> {
-        const promises = [];
+  public onStopped(session: vscode.DebugSession, frameId: number) {
+    for (const rtosSession of this.sessionMap.values()) {
+      if (rtosSession.session.id === session.id) {
+        rtosSession.lastFrameId = frameId;
         if (this.enabled && this.visible) {
-            for (const rtosSession of this.sessionMap.values()) {
-                promises.push(rtosSession.refresh());
-            }
+          rtosSession.onStopped(frameId).then(() => {
+            this.provider.updateHtml();
+          });
         }
-        return Promise.all(promises);
+        break;
+      }
     }
+  }
 
-    public toggleRTOSPanel() {
-        this.enabled = !this.enabled;
-        this.updateRTOSPanelStatus();
+  public onContinued(session: vscode.DebugSession) {
+    for (const rtosSession of this.sessionMap.values()) {
+      if (rtosSession.session.id === session.id) {
+        rtosSession.onContinued();
+      }
     }
+  }
 
-    private updateRTOSPanelStatus() {
-        const config = vscode.workspace.getConfiguration('mcu-debug.rtos-views', null);
-        config.update('showRTOS', this.enabled);
-        vscode.commands.executeCommand('setContext', 'mcu-debug.rtos-views:showRTOS', this.enabled);
-        /*
+  public onStarted(session: vscode.DebugSession) {
+    this.sessionMap.set(session.id, new RTOSSession(session));
+  }
+
+  public onTerminated(session: vscode.DebugSession) {
+    const s = this.sessionMap.get(session.id);
+    if (s) {
+      s.onExited();
+      this.sessionMap.delete(session.id);
+    }
+  }
+
+  // Only updates the RTOS state. Only debug sessions that are currently stopped will be updated
+  public async updateRTOSInfo(): Promise<any> {
+    const promises = [];
+    if (this.enabled && this.visible) {
+      for (const rtosSession of this.sessionMap.values()) {
+        promises.push(rtosSession.refresh());
+      }
+    }
+    return Promise.all(promises);
+  }
+
+  public toggleRTOSPanel() {
+    this.enabled = !this.enabled;
+    this.updateRTOSPanelStatus();
+  }
+
+  private updateRTOSPanelStatus() {
+    const config = vscode.workspace.getConfiguration("mcu-debug.rtos-views", null);
+    config.update("showRTOS", this.enabled);
+    vscode.commands.executeCommand("setContext", "mcu-debug.rtos-views:showRTOS", this.enabled);
+    /*
         if (this.enabled) {
             this.provider.showAndFocus();
         }
         this.update();
         */
-    }
+  }
 
-    public notifyPanelDisposed() {
-        this.enabled = this.visible = false;
-        this.updateRTOSPanelStatus();
-    }
+  public notifyPanelDisposed() {
+    this.enabled = this.visible = false;
+    this.updateRTOSPanelStatus();
+  }
 
-    public async visibilityChanged(v: boolean) {
-        if (v !== this.visible) {
-            this.visible = v;
-            if (this.visible) {
-                const msg = 'RTOS Views: Some sessions are busy. RTOS panel will be updated when session is paused';
-                for (const rtosSession of this.sessionMap.values()) {
-                    if (rtosSession.lastFrameId === undefined) {
-                        if (msg) {
-                            vscode.window.showInformationMessage(msg);
-                            break;
-                        }
-                    }
-                }
-            }
-            try {
-                await this.update();
-            }
-            catch { }
-        }
-    }
-
-    // Updates RTOS state and the Panel HTML
-    private busyHtml: RTOSCommon.HtmlInfo | undefined;
-    public update(): Promise<void> {
-        return new Promise<void>((resolve) => {
-            if (!this.enabled || !this.visible || !this.sessionMap.size) {
-                resolve();
-            }
-            this.busyHtml = { html: /*html*/'<h4>RTOS Views: Busy updating...</h4>\n', css: '' };
-            this.provider.updateHtml();
-            this.updateRTOSInfo().then(() => {
-                this.busyHtml = undefined;
-                this.provider.updateHtml();
-                resolve();
-            }, (e) => {
-                this.busyHtml = undefined;
-                this.provider.updateHtml();
-                resolve();
-            });
-        });
-    }
-
-    private lastGoodHtmlContent: RTOSCommon.HtmlInfo | undefined;
-    public getHtml(): RTOSCommon.HtmlInfo {
-        const ret: RTOSCommon.HtmlInfo = { html: '', css: '' };
-
-        if (this.busyHtml) {
-            return this.busyHtml;
-        } else if (this.sessionMap.size === 0) {
-            if (this.lastGoodHtmlContent) {
-                return this.lastGoodHtmlContent;
-            } else {
-                ret.html = '<p>RTOS Views: No active/compatible debug sessions running.</p>\n';
-                return ret;
-            }
-        } else if (!this.visible || !this.enabled) {
-            ret.html = '<p>RTOS Views: Contents are not visible, so no html generated</p>\n';
-            return ret;
-        }
-
+  public async visibilityChanged(v: boolean) {
+    if (v !== this.visible) {
+      this.visible = v;
+      if (this.visible) {
+        const msg = "RTOS Views: Some sessions are busy. RTOS panel will be updated when session is paused";
         for (const rtosSession of this.sessionMap.values()) {
-            const name = `RTOS Views: Session Name: "${rtosSession.session.name}"`;
-            if (!rtosSession.rtos) {
-                const nameAndStatus = name + ' -- No RTOS detected';
-                ret.html += /*html*/`<h4>${nameAndStatus}</h4>\n`;
-                if (rtosSession.triedAndFailed) {
-                    const supported = Object.keys(RTOS_TYPES).join(', ');
-                    ret.html += `<p>RTOS Views: Failed to match any supported RTOS. Supported RTOSes are (${supported}). ` +
-                        'Please report issues and/or contribute code/knowledge to add your RTOS</p>\n';
-                } else {
-                    ret.html += /*html*/'<p>RTOS Views: Try refreshing this panel. RTOS detection may be still in progress</p>\n';
-                }
-            } else {
-                const nameAndStatus = name + ', ' + rtosSession.rtos.name + ' detected.' + (!rtosSession.htmlContent ? ' (No data available yet)' : '');
-                ret.html += /*html*/`<h4>${nameAndStatus}</h4>\n` + rtosSession.htmlContent.html;
-                ret.css = rtosSession.htmlContent.css;
+          if (rtosSession.lastFrameId === undefined) {
+            if (msg) {
+              vscode.window.showInformationMessage(msg);
+              break;
             }
+          }
         }
-        this.lastGoodHtmlContent = ret;
-        return ret;
+      }
+      try {
+        await this.update();
+      } catch {}
     }
+  }
+
+  // Updates RTOS state and the Panel HTML
+  private busyHtml: RTOSCommon.HtmlInfo | undefined;
+  public update(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      if (!this.enabled || !this.visible || !this.sessionMap.size) {
+        resolve();
+      }
+      this.busyHtml = { html: /*html*/ "<h4>RTOS Views: Busy updating...</h4>\n", css: "" };
+      this.provider.updateHtml();
+      this.updateRTOSInfo().then(
+        () => {
+          this.busyHtml = undefined;
+          this.provider.updateHtml();
+          resolve();
+        },
+        (e) => {
+          this.busyHtml = undefined;
+          this.provider.updateHtml();
+          resolve();
+        }
+      );
+    });
+  }
+
+  private lastGoodHtmlContent: RTOSCommon.HtmlInfo | undefined;
+  public getHtml(): RTOSCommon.HtmlInfo {
+    const ret: RTOSCommon.HtmlInfo = { html: "", css: "" };
+
+    if (this.busyHtml) {
+      return this.busyHtml;
+    } else if (this.sessionMap.size === 0) {
+      if (this.lastGoodHtmlContent) {
+        return this.lastGoodHtmlContent;
+      } else {
+        ret.html = "<p>RTOS Views: No active/compatible debug sessions running.</p>\n";
+        return ret;
+      }
+    } else if (!this.visible || !this.enabled) {
+      ret.html = "<p>RTOS Views: Contents are not visible, so no html generated</p>\n";
+      return ret;
+    }
+
+    for (const rtosSession of this.sessionMap.values()) {
+      const name = `RTOS Views: Session Name: "${rtosSession.session.name}"`;
+      if (!rtosSession.rtos) {
+        const nameAndStatus = name + " -- No RTOS detected";
+        ret.html += /*html*/ `<h4>${nameAndStatus}</h4>\n`;
+        if (rtosSession.triedAndFailed) {
+          const supported = Object.keys(RTOS_TYPES).join(", ");
+          ret.html +=
+            `<p>RTOS Views: Failed to match any supported RTOS. Supported RTOSes are (${supported}). ` +
+            "Please report issues and/or contribute code/knowledge to add your RTOS</p>\n";
+        } else {
+          ret.html +=
+            /*html*/ "<p>RTOS Views: Try refreshing this panel. RTOS detection may be still in progress</p>\n";
+        }
+      } else {
+        const nameAndStatus =
+          name +
+          ", " +
+          rtosSession.rtos.name +
+          " detected." +
+          (!rtosSession.htmlContent ? " (No data available yet)" : "");
+        ret.html += /*html*/ `<h4>${nameAndStatus}</h4>\n` + rtosSession.htmlContent.html;
+        ret.css = rtosSession.htmlContent.css;
+      }
+    }
+    this.lastGoodHtmlContent = ret;
+    return ret;
+  }
 }
 
 class RTOSViewProvider implements vscode.WebviewViewProvider {
-    public static readonly viewType = 'rtos-views.rtos';
-    private webviewView: vscode.WebviewView | undefined;
+  public static readonly viewType = "rtos-views.rtos";
+  private webviewView: vscode.WebviewView | undefined;
 
-    constructor(private readonly extensionUri: vscode.Uri, private parent: RTOSTracker) { }
+  constructor(private readonly extensionUri: vscode.Uri, private parent: RTOSTracker) {}
 
-    public resolveWebviewView(
-        webviewView: vscode.WebviewView,
-        context: vscode.WebviewViewResolveContext,
-        token: vscode.CancellationToken
-    ) {
-        this.webviewView = webviewView;
-        this.parent.visible = this.webviewView.visible;
-        this.parent.enabled = true;
+  public resolveWebviewView(
+    webviewView: vscode.WebviewView,
+    context: vscode.WebviewViewResolveContext,
+    token: vscode.CancellationToken
+  ) {
+    this.webviewView = webviewView;
+    this.parent.visible = this.webviewView.visible;
+    this.parent.enabled = true;
 
-        webviewView.webview.options = {
-            // Allow scripts in the webview
-            enableScripts: true,
-            localResourceRoots: [this.extensionUri]
-        };
-        this.webviewView.description = 'View RTOS internals';
+    webviewView.webview.options = {
+      // Allow scripts in the webview
+      enableScripts: true,
+      localResourceRoots: [this.extensionUri],
+    };
+    this.webviewView.description = "View RTOS internals";
 
-        this.webviewView.onDidDispose((e) => {
-            this.webviewView = undefined;
-            this.parent.notifyPanelDisposed();
-        });
+    this.webviewView.onDidDispose((e) => {
+      this.webviewView = undefined;
+      this.parent.notifyPanelDisposed();
+    });
 
-        this.webviewView.onDidChangeVisibility((e) => {
-            if (this.webviewView) {
-                this.parent.visibilityChanged(this.webviewView.visible);
-            }
-        });
+    this.webviewView.onDidChangeVisibility((e) => {
+      if (this.webviewView) {
+        this.parent.visibilityChanged(this.webviewView.visible);
+      }
+    });
 
-        this.updateHtml();
+    this.updateHtml();
 
-        webviewView.webview.onDidReceiveMessage((msg) => {
-            switch (msg?.type) {
-                case 'refresh': {
-                    this.parent.update();
-                    break;
-                }
-            }
-        });
-    }
-
-    public showAndFocus() {
-        if (this.webviewView) {
-            this.webviewView.show(false);
+    webviewView.webview.onDidReceiveMessage((msg) => {
+      switch (msg?.type) {
+        case "refresh": {
+          this.parent.update();
+          break;
         }
-    }
+      }
+    });
+  }
 
-    public updateHtml() {
-        if (this.webviewView) {
-            this.webviewView.webview.html = this.getHtmlForWebview();
-            // console.log(this.webviewView.webview.html);
-        }
+  public showAndFocus() {
+    if (this.webviewView) {
+      this.webviewView.show(false);
     }
+  }
 
-    private getHtmlForWebview(): string {
-        const webview = this.webviewView?.webview;
-        if (!webview) {
-            return '';
-        }
-        if (!this.parent.enabled) {
-            return /*html*/`
+  public updateHtml() {
+    if (this.webviewView) {
+      this.webviewView.webview.html = this.getHtmlForWebview();
+      // console.log(this.webviewView.webview.html);
+    }
+  }
+
+  private getHtmlForWebview(): string {
+    const webview = this.webviewView?.webview;
+    if (!webview) {
+      return "";
+    }
+    if (!this.parent.enabled) {
+      return /*html*/ `
                 <!DOCTYPE html>
                 <html lang="en">
                 <head>
@@ -485,22 +501,22 @@ class RTOSViewProvider implements vscode.WebviewViewProvider {
                     <p>Currently disabled. Enable setting "mcu-debug.rtos-views.showRTOS" or use Command "RTOS Views: Toggle RTOS Panel" to see any RTOS info</p>
                 </body>
                 </html>`;
-        }
-        const toolkitUri = getUri(webview, this.extensionUri, [
-            'node_modules',
-            '@vscode',
-            'webview-ui-toolkit',
-            'dist',
-            'toolkit.js'
-        ]);
-        // Get the local path to main script run in the webview, then convert it to a uri we can use in the webview.
-        const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'dist', 'rtos-view.js'));
-        const rtosStyle = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'resources', 'rtos.css'));
+    }
+    const toolkitUri = getUri(webview, this.extensionUri, [
+      "node_modules",
+      "@vscode",
+      "webview-ui-toolkit",
+      "dist",
+      "toolkit.js",
+    ]);
+    // Get the local path to main script run in the webview, then convert it to a uri we can use in the webview.
+    const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "dist", "rtos-view.js"));
+    const rtosStyle = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "resources", "rtos.css"));
 
-        const htmlInfo = this.parent.getHtml();
-        // Use a nonce to only allow a specific script to be run.
-        const nonce = getNonce();
-        const ret = /*html*/`
+    const htmlInfo = this.parent.getHtml();
+    // Use a nonce to only allow a specific script to be run.
+    const nonce = getNonce();
+    const ret = /*html*/ `
             <!DOCTYPE html>
             <html lang="en">
             <head>
@@ -524,49 +540,47 @@ class RTOSViewProvider implements vscode.WebviewViewProvider {
                 <script type="module" nonce="${nonce}" src="${scriptUri}"></script>
             </body>
             </html>`;
-        writeHtmlToTmpDir(ret);
-        return ret;
-    }
+    writeHtmlToTmpDir(ret);
+    return ret;
+  }
 }
 
 function writeHtmlToTmpDir(str: string) {
-    try {
-        if (false) {
-            const fname = path.join(os.tmpdir(), 'rtos.html');
-            console.log(`Write HTML to file ${fname}`);
-            fs.writeFileSync(fname, str);
-        }
+  try {
+    if (false) {
+      const fname = path.join(os.tmpdir(), "rtos.html");
+      console.log(`Write HTML to file ${fname}`);
+      fs.writeFileSync(fname, str);
     }
-    catch (e) {
-        console.log(e ? e.toString() : 'unknown exception?');
-    }
+  } catch (e) {
+    console.log(e ? e.toString() : "unknown exception?");
+  }
 }
 
 function appendMsgToTmpDir(str: string) {
-    try {
-        if (false) {
-            const fname = path.join(os.tmpdir(), 'rtos-msgs.txt');
-            console.log(`Write ${str} to file ${fname}`);
-            if (!str.endsWith('\n')) {
-                str = str + '\n';
-            }
-            fs.appendFileSync(fname, str);
-        }
+  try {
+    if (false) {
+      const fname = path.join(os.tmpdir(), "rtos-msgs.txt");
+      console.log(`Write ${str} to file ${fname}`);
+      if (!str.endsWith("\n")) {
+        str = str + "\n";
+      }
+      fs.appendFileSync(fname, str);
     }
-    catch (e) {
-        console.log(e ? e.toString() : 'unknown exception?');
-    }
+  } catch (e) {
+    console.log(e ? e.toString() : "unknown exception?");
+  }
 }
 
 function getNonce() {
-    let text = '';
-    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    for (let i = 0; i < 32; i++) {
-        text += possible.charAt(Math.floor(Math.random() * possible.length));
-    }
-    return text;
+  let text = "";
+  const possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  for (let i = 0; i < 32; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
 }
 
 export function getUri(webview: vscode.Webview, extensionUri: vscode.Uri, pathList: string[]) {
-    return webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, ...pathList));
+  return webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, ...pathList));
 }


### PR DESCRIPTION
Add Zephyr support

First work in progress state:
![grafik](https://user-images.githubusercontent.com/5595052/201445034-f87cc592-bfbb-4974-bd6b-ee97fbd5ea3a.png)

For tests I'm currently using
`west build -p always -b nucleo_f429zi samples\basic\threads -DCONFIG_THREAD_MONITOR=y -DCONFIG_THREAD_NAME=y`

`west build -p always -b nucleo_f429zi samples\basic\threads -DCONFIG_DEBUG_THREAD_INFO=y` should also work and get's the J-Link Plugin working too

# Open points
- [ ] Inform user when `CONFIG_THREAD_MONITOR` is not set
- [ ] Check if stack_info.size is always in Bytes and not number of stack entries
- [ ] Add support for more arches and inform user when not supported (it's not always `callee_saved.psp`)
- [ ] Try to get information like real address and type of kernel objects (semaphore, mutex etc.) the tasks are pending on (we only have their `_wait_q_t *pended_on` right now) => when  `CONFIG_TRACING ` and `CONFIG_TRACING_OBJECT_TRACKING` are enabled, it seems that we have lists of all object types => see `tracing_tracking.c` for link list entry points
