### PR TITLE
Fix issue with embOS not working

### DIFF
--- a/src/rtos/rtos-chibios.ts
+++ b/src/rtos/rtos-chibios.ts
@@ -176,7 +176,7 @@ export class RTOSChibiOS extends RTOSCommon.RTOSBase {
         const currentThreadCtxRegs = currentThreadCtx ? await this.getVarChildrenObj(currentThreadCtx['sp']?.ref, 'sp') : null;
 
         if (currentThreadCtxRegs && currentThreadCtx) {
-            sp = getNumberNVL(Object.hasOwn(currentThreadCtxRegs, 'r13-val') ? currentThreadCtxRegs['r13']?.val : currentThreadCtx['sp']?.val, 0);
+            sp = getNumberNVL(Object.hasOwn(currentThreadCtxRegs, 'r13') ? currentThreadCtxRegs['r13']?.val : currentThreadCtx['sp']?.val, 0);
         }
 
         return sp;

--- a/src/rtos/rtos-embos.ts
+++ b/src/rtos/rtos-embos.ts
@@ -56,7 +56,7 @@ export class RTOSEmbOS extends RTOSCommon.RTOSBase {
     private timeInfo: string = '';
     private readonly maxThreads = 1024;
 
-    private stackPattern = 0x00;
+    private stackPattern = 0xCD; /* Seems that OS_TASK_CREATE() does initialize the stack to 0xCD */
     private stackIncrements = -1; /* negative numbers => high to low address growth on stack (OS_STACK_GROWS_TOWARD_HIGHER_ADDR = 0) */
 
     private helpHtml: string | undefined;

--- a/src/rtos/rtos-embos.ts
+++ b/src/rtos/rtos-embos.ts
@@ -151,7 +151,7 @@ export class RTOSEmbOS extends RTOSCommon.RTOSBase {
 
                     let isRunning: any = '0';
 
-                    if (this.OSGlobalVal.hasOwn('IsRunning-val')) {
+                    if (Object.hasOwn(this.OSGlobalVal, 'IsRunning')) {
                         isRunning = this.OSGlobalVal['IsRunning']?.val;
                     }
                     else {

--- a/src/rtos/rtos-embos.ts
+++ b/src/rtos/rtos-embos.ts
@@ -223,11 +223,11 @@ export class RTOSEmbOS extends RTOSCommon.RTOSBase {
                     do {
                         let thName = '???';
 
-                        if (Object.hasOwn(curTaskObj, 'sName-val')) {
+                        if (Object.hasOwn(curTaskObj, 'sName')) {
                             const matchName = curTaskObj['sName']?.val.match(/"([^*]*)"$/);
                             thName = matchName ? matchName[1] : curTaskObj['sName']?.val;
                         }
-                        else if (Object.hasOwn(curTaskObj, 'Name-val')) { /* older embOS versions used Name */
+                        else if (Object.hasOwn(curTaskObj, 'Name')) { /* older embOS versions used Name */
                             const matchName = curTaskObj['Name']?.val.match(/"([^*]*)"$/);
                             thName = matchName ? matchName[1] : curTaskObj['Name']?.val;
                         }
@@ -384,7 +384,7 @@ export class RTOSEmbOS extends RTOSCommon.RTOSBase {
         const StackSize = thInfo['StackSize']?.val;
         let EndOfStack: any;
 
-        if (Object.hasOwn(thInfo, 'pStackBase-val')) {
+        if (Object.hasOwn(thInfo, 'pStackBase')) {
             EndOfStack = thInfo['pStackBase']?.val;
         }
         else {


### PR DESCRIPTION
Due to the object changes the embOS implementation wasn't working anymore.

Also remove some `-val` in the `hasOwn()` checks in embOS and ChibiOS implementation

At least newest embOS (haven't checked others) does set the stack pattern to `0xCD` so i set this to be de default.

Can still be overwritten with a setting (we should make that one public, but that's another story)