### PR TITLE
runtime % support for FreeRTOS V11

### DIFF
--- a/src/rtos/rtos-freertos.ts
+++ b/src/rtos/rtos-freertos.ts
@@ -95,6 +95,8 @@ export class RTOSFreeRTOS extends RTOSCommon.RTOSBase {
     private xSuspendedTaskList: RTOSCommon.RTOSVarHelperMaybe;
     private xTasksWaitingTermination: RTOSCommon.RTOSVarHelperMaybe;
     private ulTotalRunTime: RTOSCommon.RTOSVarHelperMaybe;
+    private ulTotalRunTimeArray: RTOSCommon.RTOSVarHelperMaybe[] = [];
+    private ulTotalRunTimeArraySize: RTOSCommon.RTOSVarHelperMaybe;
     private ulTotalRunTimeVal = 0;
 
     private stale = true;
@@ -164,7 +166,30 @@ export class RTOSFreeRTOS extends RTOSCommon.RTOSBase {
                     'xTasksWaitingTermination',
                     true
                 );
-                this.ulTotalRunTime = await this.getVarIfEmpty(this.ulTotalRunTime, useFrameId, 'ulTotalRunTime', true);
+                this.ulTotalRunTimeArraySize = await this.getVarIfEmpty(
+                    this.ulTotalRunTimeArraySize,
+                    useFrameId,
+                    'sizeof(ulTotalRunTime) / sizeof(ulTotalRunTime[0])',
+                    true
+                );
+                const nCores = parseInt((await this.ulTotalRunTimeArraySize?.getValue(useFrameId)) || '');
+                if (nCores) {
+                    for (let i = 0; i < nCores; i++) {
+                        this.ulTotalRunTimeArray[i] = await this.getVarIfEmpty(
+                            this.ulTotalRunTimeArray[i],
+                            useFrameId,
+                            `ulTotalRunTime[${i}]`,
+                            true
+                        );
+                    }
+                } else {
+                    this.ulTotalRunTime = await this.getVarIfEmpty(
+                        this.ulTotalRunTime,
+                        useFrameId,
+                        'ulTotalRunTime',
+                        true
+                    );
+                }
                 this.status = 'initialized';
             }
             return this;
@@ -245,19 +270,37 @@ export class RTOSFreeRTOS extends RTOSCommon.RTOSBase {
 
     private updateTotalRuntime(frameId: number): Promise<void> {
         return new Promise<void>((resolve, reject) => {
-            if (!this.ulTotalRunTime) {
-                resolve();
-                return;
-            }
-            this.ulTotalRunTime.getValue(frameId).then(
-                (ret) => {
-                    this.ulTotalRunTimeVal = parseInt(ret || '');
-                    resolve();
-                },
-                (e) => {
-                    reject(e);
+            if (this.ulTotalRunTimeArray.length) {
+                const promises = [];
+                for (const rtVar of this.ulTotalRunTimeArray) {
+                    promises.push(rtVar?.getValue(frameId));
                 }
-            );
+                Promise.all(promises).then(
+                    (rtStrs) => {
+                        let total = 0;
+                        for (const rtStr of rtStrs) {
+                            total += parseInt(rtStr || '');
+                        }
+                        this.ulTotalRunTimeVal = total;
+                        resolve();
+                    },
+                    (e) => {
+                        reject(e);
+                    }
+                );
+            } else if (this.ulTotalRunTime) {
+                this.ulTotalRunTime.getValue(frameId).then(
+                    (ret) => {
+                        this.ulTotalRunTimeVal = parseInt(ret || '');
+                        resolve();
+                    },
+                    (e) => {
+                        reject(e);
+                    }
+                );
+            } else {
+                resolve();
+            }
         });
     }
 


### PR DESCRIPTION
In V11, FreeRTOS changed `ulTotalRunTime` from an integer to an array of integers. On SMP, the array has one entry per CPU, but it's still a one-element array even without SMP support compiled in.

Try finding the length of the array with `sizeof(a)/sizeof(a[0])`. If that succeeds, sum all CPU runtimes to get the total runtime. If it fails, assume V10 or earlier and fall back to the previous technique.