### PR TITLE
Add possibilitiy to register new debug trackers, like the memory-viewer. Pre-register the MPLAB Debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,12 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Determining stack peaks requires that stack memory be read to determine a high water mark. Stack peaks are useful but can be expensive in runtime."
+                },
+                "mcu-debug.rtos-views.trackDebuggers": {
+                    "type": "array",
+                    "items": "string",
+                    "default": [],
+                    "description": "List (array) of additional debuggers to track besides the default ones. Reload of window required"
                 }
             }
         },

--- a/src/rtos/rtos.ts
+++ b/src/rtos/rtos.ts
@@ -24,6 +24,7 @@ export const TrackedDebuggers = [
     'cortex-debug',
     'cppdbg', // Microsoft debugger
     'cspy', // IAR debugger
+    'mplab-core-da' // Microchip debugger
 ];
 
 let trackerApi: IDebugTracker;


### PR DESCRIPTION
This change implements the same registration configuration key as in the mcu-debug.memory-view extension.

It also adds the [MPLAB Debugger](https://marketplace.visualstudio.com/items?itemName=Microchip.mplab-core-da) as a tracked target.