### PR TITLE
Add FS-RTOS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 - Read stackTop for current running task with function contributed by @malsyned also in uc/OS-II.
+- Add FS-RTOS support. FS-RTOS is very similar to uC/OS-II, so no need to create a own implementation for it.
 
 ## 0.0.14-pre1 - Jan 14, 2026
 


### PR DESCRIPTION
FS-RTOS is very similar to uC/OS-II, so no need to create a own implementation for it. We simply need to convert the event type enumeration / values.