### PR TITLE
Add support for Renesas Electronics debuggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Read stackTop for current running task with function contributed by @malsyned also in uc/OS-II.
 - Add FS-RTOS support. FS-RTOS is very similar to uC/OS-II, so no need to create a own implementation for it.
 - Add another tab to ThreadX to display byte pools.
+- Contribution to support for Renesas Electronics GDB hardware and simulator debugger
 
 ## 0.0.14 - Jan 25, 2026
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
         "onDebugResolve:cspy",
         "onDebugResolve:gdbtarget",
         "onDebugResolve:stlinkgdbtarget",
-        "onDebugResolve:jlinkgdbtarget"
+        "onDebugResolve:jlinkgdbtarget",
+        "onDebugResolve:renesas-hardware",
+        "onDebugResolve:renesas-simulator"
     ],
     "main": "./dist/extension.js",
     "contributes": {

--- a/src/rtos/rtos.ts
+++ b/src/rtos/rtos.ts
@@ -32,6 +32,8 @@ export const TrackedDebuggers = [
     'gdbtarget', // Eclipse-CDT-GDB debugger
     'stlinkgdbtarget', // STMicroelectronics ST-Link debugger
     'jlinkgdbtarget', // STMicroelectronics J-Link debugger
+    'renesas-hardware', // Renesas GDB hardware debugger
+    'renesas-simulator', // Renesas Simulator debugger
 ];
 
 let trackerApi: IDebugTracker;


### PR DESCRIPTION
This PR aims to add support for the following debuggers:

- renesas-hardware (For Renesas GDB Hardware Debugging)
- renesas-simulator (For Renesas Simulator Debugging)

These debuggers are provided as part of the Renesas Platform Extension: https://marketplace.visualstudio.com/items?itemName=RenesasElectronicsCorporation.renesas-platform
They allow Renesas MCU specific VS Code projects to be debugged.