### PR TITLE
Fix promise resolution in ThreadX refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Add FS-RTOS support. FS-RTOS is very similar to uC/OS-II, so no need to create a own implementation for it.
 - Add another tab to ThreadX to display byte pools.
 - Contribution to support for Renesas Electronics GDB hardware and simulator debugger
-- Some minor improvements for ThreadX detection
+- Improve detection for ThreadX to be more reliable and add additional information on unused components.
 
 ## 0.0.14 - Jan 25, 2026
 

--- a/src/rtos/rtos-threadx.ts
+++ b/src/rtos/rtos-threadx.ts
@@ -198,80 +198,38 @@ export class RTOSThreadX extends RTOSCommon.RTOSBase {
     }
 
     public refresh(frameId: number): Promise<void> {
-        return new Promise<void>((resolve) => {
-            if (this.progStatus !== 'stopped') {
-                resolve();
-                return;
+        if (this.progStatus !== 'stopped') {
+            return Promise.resolve();
+        }
+
+        const section = (
+            helper: RTOSCommon.RTOSVarHelperMaybe,
+            getInfo: (count: number) => Promise<void>,
+            label: string,
+        ): Promise<void> => {
+            if (!helper) {
+                return Promise.resolve();
             }
-
-            this.threadCreatedCount?.getValue(frameId).then(
+            return helper.getValue(frameId).then(
                 async (str) => {
                     try {
-                        const numThreads = parseInt(str ?? '') || 0;
-                        await this.getThreadInfo(numThreads, frameId);
-                        resolve();
+                        await getInfo(parseInt(str ?? '') || 0);
                     } catch (e) {
-                        resolve();
-                        console.error('RTOSThreadX.refresh() failed: ', e);
+                        console.error(`RTOSThreadX.refresh() ${label} failed: `, e);
                     }
                 },
                 (reason) => {
-                    resolve();
-                    console.error('RTOSThreadX.refresh() failed: ', reason);
+                    console.error(`RTOSThreadX.refresh() ${label} failed: `, reason);
                 },
             );
+        };
 
-            this.semaphoreCreatedCount?.getValue(frameId).then(
-                async (str) => {
-                    try {
-                        const numSemaphores = parseInt(str ?? '') || 0;
-                        await this.getSemaphoreInfo(numSemaphores, frameId);
-                        resolve();
-                    } catch (e) {
-                        resolve();
-                        console.error('RTOSThreadX.refresh() failed: ', e);
-                    }
-                },
-                (reason) => {
-                    resolve();
-                    console.error('RTOSThreadX.refresh() failed: ', reason);
-                },
-            );
-
-            this.mutexCreatedCount?.getValue(frameId).then(
-                async (str) => {
-                    try {
-                        const numMutexes = parseInt(str ?? '') || 0;
-                        await this.getMutexInfo(numMutexes, frameId);
-                        resolve();
-                    } catch (e) {
-                        resolve();
-                        console.error('RTOSThreadX.refresh() failed: ', e);
-                    }
-                },
-                (reason) => {
-                    resolve();
-                    console.error('RTOSThreadX.refresh() failed: ', reason);
-                },
-            );
-
-            this.bytePoolCreatedCount?.getValue(frameId).then(
-                async (str) => {
-                    try {
-                        const numBytePools = parseInt(str ?? '') || 0;
-                        await this.getBytePoolInfo(numBytePools, frameId);
-                        resolve();
-                    } catch (e) {
-                        resolve();
-                        console.error('RTOSThreadX.refresh() failed: ', e);
-                    }
-                },
-                (reason) => {
-                    resolve();
-                    console.error('RTOSThreadX.refresh() failed: ', reason);
-                },
-            );
-        });
+        return Promise.all([
+            section(this.threadCreatedCount, (n) => this.getThreadInfo(n, frameId), 'threads'),
+            section(this.semaphoreCreatedCount, (n) => this.getSemaphoreInfo(n, frameId), 'semaphores'),
+            section(this.mutexCreatedCount, (n) => this.getMutexInfo(n, frameId), 'mutexes'),
+            section(this.bytePoolCreatedCount, (n) => this.getBytePoolInfo(n, frameId), 'byte pools'),
+        ]).then(() => undefined);
     }
 
     public getHTML(): RTOSCommon.HtmlInfo {

--- a/src/rtos/rtos-threadx.ts
+++ b/src/rtos/rtos-threadx.ts
@@ -295,48 +295,52 @@ export class RTOSThreadX extends RTOSCommon.RTOSBase {
                 title: `Threads
                 <vscode-badge appearance="secondary">
                 ${this.threads.length}
-                </vscode-badge>`
+                </vscode-badge>`,
             },
             {
                 title: `Semaphores
                 <vscode-badge appearance="secondary">
                 ${this.semaphores.length}
-                </vscode-badge>`
+                </vscode-badge>`,
             },
             {
                 title: `Mutexes
                 <vscode-badge appearance="secondary">
                 ${this.mutexes.length}
-                </vscode-badge>`
+                </vscode-badge>`,
             },
             {
                 title: `Byte Pools
                 <vscode-badge appearance="secondary">
                 ${this.bytePools.length}
-                </vscode-badge>`
-            }
+                </vscode-badge>`,
+            },
         ];
 
         const views = [
             {
-                content:(this.threads.length > 0)
-                ? htmlThreads.html
-                : this.getNoThreadsFoundHtml().html
+                content: this.threads.length > 0 ? htmlThreads.html : this.getNoThreadsFoundHtml().html,
             },
             {
                 content: this.semaphoreCreatedCount
-                ? ((this.semaphores.length > 0) ? htmlSemaphores.html : this.getNoObjectsCreatedHtml('Semaphores', 'tx_semaphore_create()').html)
-                : this.getObjectNotAvailableHtml('Semaphores').html
+                    ? this.semaphores.length > 0
+                        ? htmlSemaphores.html
+                        : this.getNoObjectsCreatedHtml('Semaphores', 'tx_semaphore_create()').html
+                    : this.getObjectNotAvailableHtml('Semaphores').html,
             },
             {
                 content: this.mutexCreatedCount
-                ? ((this.mutexes.length > 0) ? htmlMutexes.html : this.getNoObjectsCreatedHtml('Mutexes', 'tx_mutex_create()').html)
-                : this.getObjectNotAvailableHtml('Mutexes').html
+                    ? this.mutexes.length > 0
+                        ? htmlMutexes.html
+                        : this.getNoObjectsCreatedHtml('Mutexes', 'tx_mutex_create()').html
+                    : this.getObjectNotAvailableHtml('Mutexes').html,
             },
             {
                 content: this.bytePoolCreatedCount
-                ? ((this.bytePools.length > 0) ? htmlBytePools.html : this.getNoObjectsCreatedHtml('Byte Pools', 'tx_byte_pool_create()').html)
-                : this.getObjectNotAvailableHtml('Byte Pools').html
+                    ? this.bytePools.length > 0
+                        ? htmlBytePools.html
+                        : this.getNoObjectsCreatedHtml('Byte Pools', 'tx_byte_pool_create()').html
+                    : this.getObjectNotAvailableHtml('Byte Pools').html,
             },
         ];
 
@@ -353,7 +357,7 @@ export class RTOSThreadX extends RTOSCommon.RTOSBase {
      * @param objectName - Name of the ThreadX object in plural form.
      * @returns Help text in the form of RTOSCommon.HtmlInfo.
      */
-    private getObjectNotAvailableHtml(objectName: string): RTOSCommon.HtmlInfo{
+    private getObjectNotAvailableHtml(objectName: string): RTOSCommon.HtmlInfo {
         return {
             html: `
             <div>
@@ -362,7 +366,7 @@ export class RTOSThreadX extends RTOSCommon.RTOSBase {
                     ${objectName} not compiled or linked into the firmware that is being debugged.
                 </div>
             </div>`,
-            css: ''
+            css: '',
         };
     }
 
@@ -370,7 +374,7 @@ export class RTOSThreadX extends RTOSCommon.RTOSBase {
      * Gets the HTML help text for when no ThreadX threads are found. This function is specifically for threads only.
      * @returns Help text in the form of RTOSCommon.HtmlInfo.
      */
-    private getNoThreadsFoundHtml() : RTOSCommon.HtmlInfo {
+    private getNoThreadsFoundHtml(): RTOSCommon.HtmlInfo {
         return {
             html: `
             <div>
@@ -380,7 +384,7 @@ export class RTOSThreadX extends RTOSCommon.RTOSBase {
                     Call <code>tx_thread_create()</code> to create them if necessary.
                 </div>
             </div>`,
-            css: ''
+            css: '',
         };
     }
 
@@ -390,7 +394,7 @@ export class RTOSThreadX extends RTOSCommon.RTOSBase {
      * @param createFunctionName - Name of the tx_*_create() function used to create the ThreadX object.
      * @returns Help text in the form of RTOSCommon.HtmlInfo.
      */
-    private getNoObjectsCreatedHtml(objectName: string, createFunctionName: string) : RTOSCommon.HtmlInfo {
+    private getNoObjectsCreatedHtml(objectName: string, createFunctionName: string): RTOSCommon.HtmlInfo {
         return {
             html: `
             <div>
@@ -399,7 +403,7 @@ export class RTOSThreadX extends RTOSCommon.RTOSBase {
                     ${objectName} not created. Call <code>${createFunctionName}</code> to create them if necessary.
                 </div>
             </div>`,
-            css: ''
+            css: '',
         };
     }
 


### PR DESCRIPTION
The refresh function would cancel/exit when the first promise to read the number of a component resolved. That made the refresh unreliable, sometimes you had to press refresh a few times to get the correct view.
Now all promises need to resolve, and refresh should work reliable.

I didn't add an additional changelog entry, but instead rewrote the changelog entry from #93.
 