### PR TITLE
Fix issue where FreeRTOS viewer hints are not showing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+- FreeRTOS: Fix the issue where hints are not showing at all when Thread ID is missing.
+
 ## 0.0.15 - Mar 28, 2026
 
 - Read stackTop for current running task with function contributed by @malsyned also in uc/OS-II.

--- a/src/rtos/rtos-freertos.ts
+++ b/src/rtos/rtos-freertos.ts
@@ -249,7 +249,7 @@ export class RTOSFreeRTOS extends RTOSCommon.RTOSBase {
             this.helpHtml = '';
             try {
                 let ret = '';
-                if (!thInfo['uxTCBNumber'].val) {
+                if (!thInfo['uxTCBNumber']?.val) {
                     ret += `Thread ID missing......: Enable macro ${strong('configUSE_TRACE_FACILITY')} in FW<br>`;
                 }
                 if (!th.stackInfo.stackEnd) {


### PR DESCRIPTION
This PR aims to fix the issue where the hints in FreeRTOS view is not showing at all unless `configUSE_TRACE_FACILITY` (macro to enable Thread ID) is set to 1.
When `configUSE_TRACE_FACILITY` is set to 0, `uxTCBNumber` is not compiled or linked into the FW, causing `thInfo['uxTCBNumber']` to be `undefined`.
See: https://github.com/mcu-debug/rtos-views/blob/main/src/rtos/rtos-freertos.ts#L252C17-L252C50

TypeError exception is thrown, jumping to the `catch` block and skipping everything else. `htmlHelp` remains empty which causes the hints to not be shown.
This simple change makes `thInfo['uxTCBNumber']` optional so that exception will not be thrown.
Simple test result for this change is as follows, where the Thread ID hint is shown as well alongside other missing info:
<img width="1350" height="518" alt="image" src="https://github.com/user-attachments/assets/56e4154d-1ce4-4e5d-9340-c8b4d0475b97" />