### PR TITLE
Add API to allow registering debug type

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,13 +1,21 @@
 import * as vscode from 'vscode';
 import { RTOSTracker } from './rtos/rtos';
 
-export function activate(context: vscode.ExtensionContext) {
+export interface RTOSViewsAPI {
+    /** Register an additional debug adapter type to be tracked by RTOS Views. */
+    addDebugType(debugType: string): void;
+}
+
+export function activate(context: vscode.ExtensionContext): RTOSViewsAPI {
     context.subscriptions.push(
         vscode.commands.registerCommand('mcu-debug.rtos-views.helloWorld', () => {
             vscode.window.showInformationMessage('Hello from rtos-views!');
         })
     );
-    const rtosTracker = new RTOSTracker(context); // eslint-disable-line @typescript-eslint/no-unused-vars
+    const rtosTracker = new RTOSTracker(context);
+    return {
+        addDebugType: (debugType: string) => rtosTracker.addDebugType(debugType),
+    };
 }
 
 export function deactivate() { } // eslint-disable-line @typescript-eslint/no-empty-function

--- a/src/rtos/rtos.ts
+++ b/src/rtos/rtos.ts
@@ -192,30 +192,43 @@ class MyDebugTracker {
                     resolve(false);
                 } else {
                     trackerApi = ret;
-                    const arg: IDebuggerTrackerSubscribeArg = {
-                        version: 1,
-                        body: {
-                            debuggers: TrackedDebuggers,
-                            handler: this.debugTrackerEventHandler.bind(this),
-                            wantCurrentStatus: true,
-                            notifyAllEvents: false,
-                            // Make sure you set debugLevel to zero for production
-                            debugLevel: 0,
-                        },
-                    };
-                    const result = trackerApi.subscribe(arg);
-                    if (typeof result === 'string') {
-                        vscode.window.showErrorMessage(
-                            `Subscription failed with extension 'debug-tracker-vscode' : ${result}`
-                        );
-                        resolve(false);
-                    } else {
-                        trackerApiClientInfo = result;
-                        resolve(true);
-                    }
+                    resolve(this.doSubscribe());
                 }
             });
         });
+    }
+
+    public resubscribe(): boolean {
+        if (!trackerApi) {
+            return false;
+        }
+        if (trackerApiClientInfo) {
+            trackerApi.unsubscribe(trackerApiClientInfo.clientId);
+        }
+        return this.doSubscribe();
+    }
+
+    private doSubscribe(): boolean {
+        const arg: IDebuggerTrackerSubscribeArg = {
+            version: 1,
+            body: {
+                debuggers: TrackedDebuggers,
+                handler: this.debugTrackerEventHandler.bind(this),
+                wantCurrentStatus: true,
+                notifyAllEvents: false,
+                // Make sure you set debugLevel to zero for production
+                debugLevel: 0,
+            },
+        };
+        const result = trackerApi.subscribe(arg);
+        if (typeof result === 'string') {
+            vscode.window.showErrorMessage(
+                `Subscription failed with extension 'debug-tracker-vscode' : ${result}`
+            );
+            return false;
+        }
+        trackerApiClientInfo = result;
+        return true;
     }
 
     private settingsChanged(e: vscode.ConfigurationChangeEvent) {
@@ -406,6 +419,13 @@ export class RTOSTracker implements DebugEventHandler {
             this.provider.showAndFocus();
         }
         this.update();
+    }
+
+    public addDebugType(debugType: string): void {
+        if (!TrackedDebuggers.includes(debugType)) {
+            TrackedDebuggers.push(debugType);
+            this.theTracker.resubscribe();
+        }
     }
 
     public notifyPanelDisposed() {


### PR DESCRIPTION
- Exposed the addDebugType API in the activate function.
- Add new method in rtos.ts to resubscribe to the debug tracker. This can also be use for debug type setting change and can remove the TODO prompt to reload the window.